### PR TITLE
Remove campos não utilizados em produtos quando o mesmo tem variantes

### DIFF
--- a/catalog/custom/example.json
+++ b/catalog/custom/example.json
@@ -5,10 +5,7 @@
     "description": "Essa camiseta tem uma logo da RD Station na frente.",
     "link": "https://sualoja.myshopify.com/collections/rdstation-classics/products/t-shirt-1",
     "image_link": "https://helena-pm-loja.myshopify.com/cdn/shop/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg",
-    "price": 10.99,
-    "sku": "SKU-TSHIRT1",
     "categories": ["aparencia", "t-shirt", "novo", "logomarca"],
-    "inventory_quantity": 25,
     "status": "published",
     "variants": [
       {
@@ -39,11 +36,7 @@
     "description": "Essa camiseta tem uma logo da RD Station na frente.",
     "link": "https://sualoja.myshopify.com/collections/rdstation-classics/products/t-shirt-2",
     "image_link": "https://helena-pm-loja.myshopify.com/cdn/shop/files/Capturadetela2024-05-09180122.png",
-    "price": 12.59,
-    "compare_at_price": 15.59,
-    "sku": "SKU-TSHIRT2",
     "categories": ["aparencia", "t-shirt", "novo", "logomarca"],
-    "inventory_quantity": 20,
     "status": "published",
     "variants": [
       {
@@ -68,7 +61,20 @@
     "price": 15.59,
     "sku": "SKU-TSHIRT3",
     "categories": ["aparencia", "t-shirt", "novo", "logomarca"],
-    "inventory_quantity": 0,
+    "inventory_quantity": 5,
     "status": "unpublished"
+  },
+  {
+    "id": "RDSTATION-TSHIRT4",
+    "title": "RD Station T-Shirt 4 Clássica",
+    "description": "Essa camiseta tem uma logo da RD Station na frente.",
+    "link": "https://sualoja.myshopify.com/collections/rdstation-classics/products/t-shirt-4",
+    "image_link": "https://helena-pm-loja.myshopify.com/cdn/shop/files/Main_9129b69a-0c7b-4f66-b6cf-c4222f18028a.jpg",
+    "price": 15.59,
+    "compare_at_price": 18.59,
+    "sku": "SKU-TSHIRT4",
+    "categories": ["aparencia", "t-shirt", "logomarca"],
+    "inventory_quantity": 1,
+    "status": "published"
   }
 ]

--- a/catalog/custom/example.xml
+++ b/catalog/custom/example.xml
@@ -5,10 +5,7 @@
     <description>Essa camiseta tem uma logo da RD Station na frente.</description>
     <link>https://sualoja.myshopify.com/collections/rdstation-classics/products/t-shirt-1</link>
     <image_link>https://helena-pm-loja.myshopify.com/cdn/shop/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg</image_link>
-    <price>10.99</price>
-    <sku>SKU-TSHIRT1</sku>
     <categories>aparencia,t-shirt,novo,logomarca</categories>
-    <inventory_quantity>25</inventory_quantity>
     <status>published</status>
     <Variants>
       <Variant>
@@ -39,11 +36,7 @@
     <description>Essa camiseta tem uma logo da RD Station na frente.</description>
     <link>https://sualoja.myshopify.com/collections/rdstation-classics/products/t-shirt-1</link>
     <image_link>https://helena-pm-loja.myshopify.com/cdn/shop/files/Capturadetela2024-05-09180122.png</image_link>
-    <price>12.59</price>
-    <compare_at_price>15.59</compare_at_price>
-    <sku>SKU-TSHIRT2</sku>
     <categories>aparencia,t-shirt,novo,logomarca</categories>
-    <inventory_quantity>30</inventory_quantity>
     <status>published</status>
     <Variants>
       <Variant>
@@ -68,8 +61,22 @@
     <price>15.59</price>
     <sku>SKU-TSHIRT3</sku>
     <categories>aparencia,t-shirt,novo,logomarca</categories>
-    <inventory_quantity>0</inventory_quantity>
+    <inventory_quantity>5</inventory_quantity>
     <status>unpublished</status>
+    <Variants/>
+  </Product>
+  <Product>
+    <id>RDSTATION-TSHIRT4</id>
+    <title>RD Station T-Shirt 4 Clássica</title>
+    <description>Essa camiseta tem uma logo da RD Station na frente.</description>
+    <link>https://sualoja.myshopify.com/collections/rdstation-classics/products/t-shirt-1</link>
+    <image_link>https://helena-pm-loja.myshopify.com/cdn/shop/files/Main_9129b69a-0c7b-4f66-b6cf-c4222f18028a.jpg</image_link>
+    <price>15.59</price>
+    <compare_at_price>18.59</compare_at_price>
+    <sku>SKU-TSHIRT4</sku>
+    <categories>aparencia,t-shirt,logomarca</categories>
+    <inventory_quantity>1</inventory_quantity>
+    <status>published</status>
     <Variants/>
   </Product>
 </Products>


### PR DESCRIPTION
Quando o produto tem variantes, utilizamos os campos `inventory_quantity`, `sku`, `compare_at_price` e `price` da variante e não do produto, portanto para esse caso não é necessário passar esses atributos no XML ou no JSON para o produto.

Quando o produto não tem variantes, é necessário que seja passado esses campos.

Obs.: o campo `compare_at_price` é opcional em todos os casos.